### PR TITLE
Receiving Data payload Notification type is implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ NotifierManager.addListener(object : NotifierManager.Listener {
 ```
 And you need to call below platform-specific functions in order to receive payload data properly.
 ##### Android
+Call `NotifierManager.onCreateOrOnNewIntent(intent)` on launcher Activity's `onCreate` and `onNewIntent` methods.
 ```kotlin
 override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState)
@@ -179,6 +180,8 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
 ```
 ##### iOS
+Call `NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)` on application's `didReceiveRemoteNotification` method.
+
 ```
  func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
       NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,40 @@ NotifierManager.addListener(object : NotifierManager.Listener {
 }) 
 ```
 
+
+
+#### Receive data payload
+```kotlin
+NotifierManager.addListener(object : NotifierManager.Listener {
+  override fun onPayloadData(data: PayloadData) {
+    println("Push Notification payloadData: $data") //PayloadData is just typeAlias for Map<String,*>.
+  }
+}) 
+```
+And you need to call below platform-specific functions in order to receive payload data properly.
+##### Android
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+   super.onCreate(savedInstanceState)
+      NotifierManager.onCreateOrOnNewIntent(intent)
+      ...
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        NotifierManager.onCreateOrOnNewIntent(intent)
+    }
+
+```
+##### iOS
+```
+ func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
+      NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
+      return UIBackgroundFetchResult.newData
+ }
+
+```
+
 #### Other functions
 ```kotlin
 NotifierManager.getPushNotifier().getToken() //Get current user push notification token

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "io.github.mirzemehdi"
-    version = "0.2.0-RC1"
+    version = "0.2.0"
     val sonatypeUsername = gradleLocalProperties(rootDir).getProperty("sonatypeUsername")
     val sonatypePassword = gradleLocalProperties(rootDir).getProperty("sonatypePassword")
     val gpgKeySecret = gradleLocalProperties(rootDir).getProperty("gpgKeySecret")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "io.github.mirzemehdi"
-    version = "0.1.9"
+    version = "0.2.0-RC1"
     val sonatypeUsername = gradleLocalProperties(rootDir).getProperty("sonatypeUsername")
     val sonatypePassword = gradleLocalProperties(rootDir).getProperty("sonatypePassword")
     val gpgKeySecret = gradleLocalProperties(rootDir).getProperty("gpgKeySecret")

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -27,6 +27,7 @@
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -8,13 +8,19 @@ class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
       FirebaseApp.configure()
-      NotifierManager.shared.initialize(configuration: NotificationPlatformConfigurationIos.shared)
+      AppInitializer.shared.onApplicationStart()
       
     return true
   }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
+    }
+    
+    
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
+        NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
+        return UIBackgroundFetchResult.newData
     }
     
 }

--- a/kmpnotifier/api/kmpnotifier.api
+++ b/kmpnotifier/api/kmpnotifier.api
@@ -1,3 +1,7 @@
+public final class com/mmk/kmpnotifier/extensions/NotifierManagerExtKt {
+	public static final fun onCreateOrOnNewIntent (Lcom/mmk/kmpnotifier/notification/NotifierManager;Landroid/content/Intent;)V
+}
+
 public abstract interface class com/mmk/kmpnotifier/notification/Notifier {
 	public abstract fun notify (Ljava/lang/String;Ljava/lang/String;)V
 }
@@ -12,6 +16,12 @@ public final class com/mmk/kmpnotifier/notification/NotifierManager {
 
 public abstract interface class com/mmk/kmpnotifier/notification/NotifierManager$Listener {
 	public abstract fun onNewToken (Ljava/lang/String;)V
+	public abstract fun onPayloadData (Ljava/util/Map;)V
+}
+
+public final class com/mmk/kmpnotifier/notification/NotifierManager$Listener$DefaultImpls {
+	public static fun onNewToken (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/lang/String;)V
+	public static fun onPayloadData (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/util/Map;)V
 }
 
 public abstract interface class com/mmk/kmpnotifier/notification/PushNotifier {

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
@@ -1,0 +1,19 @@
+package com.mmk.kmpnotifier.extensions
+
+import android.content.Intent
+import androidx.core.os.bundleOf
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.NotifierManagerImpl
+
+public fun NotifierManager.onCreateOrOnNewIntent(intent: Intent?) {
+    if (intent == null) return
+    val extras = intent.extras ?: bundleOf()
+    if (extras.containsKey("google.sent_time").not()) return
+
+    val payloadData = mutableMapOf<String, Any>()
+    extras.keySet().forEach { key ->
+        val value = extras.get(key)
+        value?.let { payloadData[key] = value }
+    }
+    NotifierManagerImpl.onPushPayloadData(payloadData)
+}

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
@@ -8,12 +8,10 @@ import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 public fun NotifierManager.onCreateOrOnNewIntent(intent: Intent?) {
     if (intent == null) return
     val extras = intent.extras ?: bundleOf()
-    if (extras.containsKey("google.sent_time").not()) return
-
     val payloadData = mutableMapOf<String, Any>()
     extras.keySet().forEach { key ->
         val value = extras.get(key)
         value?.let { payloadData[key] = value }
     }
-    NotifierManagerImpl.onPushPayloadData(payloadData)
+    if (extras.containsKey("google.sent_time")) NotifierManagerImpl.onPushPayloadData(payloadData)
 }

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
@@ -5,6 +5,32 @@ import androidx.core.os.bundleOf
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 
+
+/***
+ * In order to receive notification data payload this functions needs to be called in
+ * Android side in launcher Activity #onCreate and #onNewIntent methods.
+ *
+ * Example:
+ *
+ * ```
+ * class MainActivity : ComponentActivity() {
+ *     override fun onCreate(savedInstanceState: Bundle?) {
+ *         super.onCreate(savedInstanceState)
+ *         NotifierManager.onCreateOrOnNewIntent(intent)
+ *         setContent {
+ *             App()
+ *         }
+ *     }
+ *
+ *     override fun onNewIntent(intent: Intent?) {
+ *         super.onNewIntent(intent)
+ *         NotifierManager.onCreateOrOnNewIntent(intent)
+ *     }
+ *
+ * }
+ *
+ * ```
+ */
 public fun NotifierManager.onCreateOrOnNewIntent(intent: Intent?) {
     if (intent == null) return
     val extras = intent.extras ?: bundleOf()

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
@@ -20,5 +20,8 @@ internal class MyFirebaseMessagingService : FirebaseMessagingService() {
         message.notification?.let {
             notifier.notify(it.title ?: "", it.body ?: "")
         }
+        if (message.data.isNotEmpty()){
+            notifierFactory.onPushPayloadData(message.data)
+        }
     }
 }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
@@ -42,7 +42,7 @@ public object NotifierManager {
          * Called when push notification token is updated, or initialized first time
          * @param token Push Notification token
          */
-        public fun onNewToken(token: String)
+        public fun onNewToken(token: String){}
 
         /**
          * Called when push notification data is available

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
@@ -43,6 +43,12 @@ public object NotifierManager {
          * @param token Push Notification token
          */
         public fun onNewToken(token: String)
+
+        /**
+         * Called when push notification data is available
+         * @param data Push Notification Payload Data
+         */
+        public fun onPayloadData(data:PayloadData) {}
     }
 
 

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
@@ -31,6 +31,11 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
         listeners.forEach { it.onNewToken(token) }
     }
 
+    fun onPushPayloadData(data: PayloadData) {
+        println("Received Push Notification payload data")
+        listeners.forEach { it.onPayloadData(data) }
+    }
+
     private fun requireInitialization() {
         if (LibDependencyInitializer.isInitialized().not()) throw IllegalStateException(
             "NotifierFactory is not initialized. " +

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
@@ -33,6 +33,7 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
 
     fun onPushPayloadData(data: PayloadData) {
         println("Received Push Notification payload data")
+        if (listeners.size == 0) println("There is no listener to notify onPushPayloadData")
         listeners.forEach { it.onPayloadData(data) }
     }
 

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/PushNotifier.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/PushNotifier.kt
@@ -1,10 +1,11 @@
 package com.mmk.kmpnotifier.notification
 
+public typealias PayloadData = Map<String, *>
+
 /**
  * Class represents push notification such as Firebase Push Notification
  */
 public interface PushNotifier {
-
 
     /**
      * @return current push notification token

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
@@ -1,0 +1,13 @@
+package com.mmk.kmpnotifier.extensions
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.NotifierManagerImpl
+
+public fun NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo:Map<Any?, *>){
+    val payloadData = userInfo.keys
+        .filterNotNull()
+        .filterIsInstance<String>()
+        .associateWith { key -> userInfo[key] }
+
+    if (payloadData.containsKey("gcm.message_id")) NotifierManagerImpl.onPushPayloadData(payloadData)
+}

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
@@ -3,6 +3,19 @@ package com.mmk.kmpnotifier.extensions
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 
+/***
+ * In order to receive notification data payload this functions needs to be called in
+ * ios Swift side application didReceiveRemoteNotification function
+ *
+ * Example:
+ *
+ * ```
+ * func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
+ *   NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
+ *   return UIBackgroundFetchResult.newData
+ * }
+ * ```
+ */
 public fun NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo:Map<Any?, *>){
     val payloadData = userInfo.keys
         .filterNotNull()

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification
 
+import com.mmk.kmpnotifier.extensions.onApplicationDidReceiveRemoteNotification
 import com.mmk.kmpnotifier.permission.IosPermissionUtil
 import platform.UserNotifications.UNMutableNotificationContent
 import platform.UserNotifications.UNNotification
@@ -47,6 +48,8 @@ internal class IosNotifier(
 //            FIRMessaging.messaging()
 //                .appDidReceiveMessage(didReceiveNotificationResponse.notification.request.content.userInfo)
 
+            val userInfo = didReceiveNotificationResponse.notification.request.content.userInfo
+            NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo)
             withCompletionHandler()
         }
 

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
@@ -60,6 +60,8 @@ internal class IosNotifier(
         ) {
 //            FIRMessaging.messaging()
 //                .appDidReceiveMessage(didReceiveNotificationResponse.notification.request.content.userInfo)
+            val userInfo =willPresentNotification.request.content.userInfo
+            NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo)
             withCompletionHandler(IosPermissionUtil.NOTIFICATION_PERMISSIONS)
         }
     }

--- a/sample/api/sample.api
+++ b/sample/api/sample.api
@@ -1,3 +1,9 @@
+public final class com/mmk/kmpnotifier/sample/AppInitializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/mmk/kmpnotifier/sample/AppInitializer;
+	public final fun onApplicationStart ()V
+}
+
 public final class com/mmk/kmpnotifier/sample/AppKt {
 	public static final fun App (Landroidx/compose/runtime/Composer;I)V
 }
@@ -23,5 +29,15 @@ public final class com/mmk/kmpnotifier/sample/MainActivity : androidx/activity/C
 
 public final class com/mmk/kmpnotifier/sample/MainActivityKt {
 	public static final fun AppAndroidPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/mmk/kmpnotifier/sample/MainApplication : android/app/Application {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun onCreate ()V
+}
+
+public final class com/mmk/kmpnotifier/sample/Platform_androidKt {
+	public static final fun onApplicationStartPlatformSpecific ()V
 }
 

--- a/sample/src/androidMain/AndroidManifest.xml
+++ b/sample/src/androidMain/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:allowBackup="true"
+        android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainActivity.kt
+++ b/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainActivity.kt
@@ -6,9 +6,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.mmk.kmpnotifier.extensions.onCreateOrOnNewIntent
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
-import com.mmk.kmpnotifier.permission.AndroidPermissionUtil
 import com.mmk.kmpnotifier.permission.permissionUtil
 
 class MainActivity : ComponentActivity() {
@@ -16,12 +16,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val permissionUtil by permissionUtil()
         permissionUtil.askNotificationPermission()
-        onPushNotificationData(intent.extras)
-        NotifierManager.initialize(
-            configuration = NotificationPlatformConfiguration.Android(
-                notificationIconResId = R.drawable.ic_launcher_foreground,
-            )
-        )
+        NotifierManager.onCreateOrOnNewIntent(intent)
         setContent {
             App()
         }
@@ -29,14 +24,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        onPushNotificationData(intent?.extras)
+        NotifierManager.onCreateOrOnNewIntent(intent)
     }
 
-    private fun onPushNotificationData(extras: Bundle?){
-        extras?.keySet()?.forEach {key->
-            println("PushNotification Data key: $key, value: ${extras.get(key)}")
-        }
-    }
 }
 
 @Preview

--- a/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainActivity.kt
+++ b/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.sample
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,11 +12,11 @@ import com.mmk.kmpnotifier.permission.AndroidPermissionUtil
 import com.mmk.kmpnotifier.permission.permissionUtil
 
 class MainActivity : ComponentActivity() {
-    private val permissionUtil: AndroidPermissionUtil by permissionUtil()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val permissionUtil by permissionUtil()
         permissionUtil.askNotificationPermission()
+        onPushNotificationData(intent.extras)
         NotifierManager.initialize(
             configuration = NotificationPlatformConfiguration.Android(
                 notificationIconResId = R.drawable.ic_launcher_foreground,
@@ -23,6 +24,17 @@ class MainActivity : ComponentActivity() {
         )
         setContent {
             App()
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        onPushNotificationData(intent?.extras)
+    }
+
+    private fun onPushNotificationData(extras: Bundle?){
+        extras?.keySet()?.forEach {key->
+            println("PushNotification Data key: $key, value: ${extras.get(key)}")
         }
     }
 }

--- a/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainApplication.kt
+++ b/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/MainApplication.kt
@@ -1,0 +1,13 @@
+package com.mmk.kmpnotifier.sample
+
+import android.app.Application
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.PayloadData
+import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AppInitializer.onApplicationStart()
+    }
+}

--- a/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/Platform.android.kt
+++ b/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/Platform.android.kt
@@ -1,0 +1,12 @@
+package com.mmk.kmpnotifier.sample
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
+
+actual fun onApplicationStartPlatformSpecific() {
+    NotifierManager.initialize(
+        configuration = NotificationPlatformConfiguration.Android(
+            notificationIconResId = R.drawable.ic_launcher_foreground,
+        )
+    )
+}

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
@@ -1,7 +1,6 @@
 package com.mmk.kmpnotifier.sample
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -13,18 +12,18 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.mmk.kmpnotifier.notification.NotifierManager
-import kotlinx.coroutines.launch
+import com.mmk.kmpnotifier.notification.PayloadData
 
 @Composable
 fun App() {
     var myPushNotificationToken by remember { mutableStateOf("") }
+    var pushNotificationDataPayload by remember { mutableStateOf("") }
 
     LaunchedEffect(true) {
         NotifierManager.addListener(object : NotifierManager.Listener {
@@ -32,14 +31,21 @@ fun App() {
                 myPushNotificationToken = token
                 println("onNewToken: $token")
             }
+
+            override fun onPayloadData(data: PayloadData) {
+                pushNotificationDataPayload = data.toString()
+            }
         })
         myPushNotificationToken = NotifierManager.getPushNotifier().getToken() ?: ""
     }
 
 
-
     MaterialTheme {
-        Column (Modifier.fillMaxSize().padding(20.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+        Column(
+            Modifier.fillMaxSize().padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
             Button(onClick = {
                 val notifier = NotifierManager.getLocalNotifier()
                 notifier.notify("Title", "bodyMessage")
@@ -50,6 +56,13 @@ fun App() {
             Text(
                 modifier = Modifier.padding(20.dp),
                 text = "FirebaseToken: $myPushNotificationToken",
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Start,
+            )
+
+            Text(
+                modifier = Modifier.padding(20.dp),
+                text = "Push Notification Data payload: $pushNotificationDataPayload",
                 style = MaterialTheme.typography.body1,
                 textAlign = TextAlign.Start,
             )

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
@@ -23,17 +23,11 @@ import com.mmk.kmpnotifier.notification.PayloadData
 @Composable
 fun App() {
     var myPushNotificationToken by remember { mutableStateOf("") }
-    var pushNotificationDataPayload by remember { mutableStateOf("") }
-
     LaunchedEffect(true) {
         NotifierManager.addListener(object : NotifierManager.Listener {
             override fun onNewToken(token: String) {
                 myPushNotificationToken = token
                 println("onNewToken: $token")
-            }
-
-            override fun onPayloadData(data: PayloadData) {
-                pushNotificationDataPayload = data.toString()
             }
         })
         myPushNotificationToken = NotifierManager.getPushNotifier().getToken() ?: ""
@@ -56,13 +50,6 @@ fun App() {
             Text(
                 modifier = Modifier.padding(20.dp),
                 text = "FirebaseToken: $myPushNotificationToken",
-                style = MaterialTheme.typography.body1,
-                textAlign = TextAlign.Start,
-            )
-
-            Text(
-                modifier = Modifier.padding(20.dp),
-                text = "Push Notification Data payload: $pushNotificationDataPayload",
                 style = MaterialTheme.typography.body1,
                 textAlign = TextAlign.Start,
             )

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
@@ -1,0 +1,21 @@
+package com.mmk.kmpnotifier.sample
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.PayloadData
+
+
+object AppInitializer {
+    fun onApplicationStart(){
+        onApplicationStartPlatformSpecific()
+        NotifierManager.addListener(object : NotifierManager.Listener {
+            override fun onNewToken(token: String) {
+                println("Push Notification onNewToken: $token")
+            }
+
+            override fun onPayloadData(data: PayloadData) {
+                super.onPayloadData(data)
+                println("Push Notification payloadData: $data")
+            }
+        })
+    }
+}

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/Platform.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/Platform.kt
@@ -1,0 +1,3 @@
+package com.mmk.kmpnotifier.sample
+
+expect fun onApplicationStartPlatformSpecific()

--- a/sample/src/iosMain/kotlin/com/mmk/kmpnotifier/sample/Platform.ios.kt
+++ b/sample/src/iosMain/kotlin/com/mmk/kmpnotifier/sample/Platform.ios.kt
@@ -1,0 +1,8 @@
+package com.mmk.kmpnotifier.sample
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
+
+actual fun onApplicationStartPlatformSpecific() {
+    NotifierManager.initialize(NotificationPlatformConfiguration.Ios)
+}


### PR DESCRIPTION
#### Receive data payload
```kotlin
NotifierManager.addListener(object : NotifierManager.Listener {
  override fun onPayloadData(data: PayloadData) {
    println("Push Notification payloadData: $data") //PayloadData is just typeAlias for Map<String,*>.
  }
}) 
```
And you need to call below platform-specific functions in order to receive payload data properly.
##### Android
Call `NotifierManager.onCreateOrOnNewIntent(intent)` on launcher Activity's `onCreate` and `onNewIntent` methods.
```kotlin
override fun onCreate(savedInstanceState: Bundle?) {
   super.onCreate(savedInstanceState)
      NotifierManager.onCreateOrOnNewIntent(intent)
      ...
    }

    override fun onNewIntent(intent: Intent?) {
        super.onNewIntent(intent)
        NotifierManager.onCreateOrOnNewIntent(intent)
    }

```
##### iOS
Call `NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)` on application's `didReceiveRemoteNotification` method.

```
 func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
      NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
      return UIBackgroundFetchResult.newData
 }

```