### PR TITLE
Implementing Notification click listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
     }
 
 ```
+
 ##### iOS
 Call `NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)` on application's `didReceiveRemoteNotification` method.
 
@@ -228,7 +229,20 @@ Call `NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: userIn
       return UIBackgroundFetchResult.newData
  }
 
-```
+```  
+
+
+#### Detecting notification click and get payload data
+Make sure you follow previous step for getting payload data properly.
+```kotlin
+NotifierManager.addListener(object : NotifierManager.Listener {
+    override fun onNotificationClicked(data: PayloadData) {
+        super.onNotificationClicked(data)
+        println("Notification clicked, Notification payloadData: $data")
+    }
+}) 
+```   
+
 
 #### Other functions
 ```kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 allprojects {
     group = "io.github.mirzemehdi"
-    version = "0.4.0"
+    version = "0.5.0"
     val sonatypeUsername = gradleLocalProperties(rootDir).getProperty("sonatypeUsername")
     val sonatypePassword = gradleLocalProperties(rootDir).getProperty("sonatypePassword")
     val gpgKeySecret = gradleLocalProperties(rootDir).getProperty("gpgKeySecret")

--- a/kmpnotifier/api/kmpnotifier.api
+++ b/kmpnotifier/api/kmpnotifier.api
@@ -19,12 +19,14 @@ public final class com/mmk/kmpnotifier/notification/NotifierManager {
 
 public abstract interface class com/mmk/kmpnotifier/notification/NotifierManager$Listener {
 	public abstract fun onNewToken (Ljava/lang/String;)V
+	public abstract fun onNotificationClicked (Ljava/util/Map;)V
 	public abstract fun onPayloadData (Ljava/util/Map;)V
 	public abstract fun onPushNotification (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/mmk/kmpnotifier/notification/NotifierManager$Listener$DefaultImpls {
 	public static fun onNewToken (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/lang/String;)V
+	public static fun onNotificationClicked (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/util/Map;)V
 	public static fun onPayloadData (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/util/Map;)V
 	public static fun onPushNotification (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;Ljava/lang/String;Ljava/lang/String;)V
 }

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
@@ -2,6 +2,8 @@ package com.mmk.kmpnotifier.extensions
 
 import android.content.Intent
 import androidx.core.os.bundleOf
+import com.mmk.kmpnotifier.Constants.ACTION_NOTIFICATION_CLICK
+import com.mmk.kmpnotifier.Constants.KEY_ANDROID_FIREBASE_NOTIFICATION
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
@@ -36,11 +38,22 @@ public fun NotifierManager.onCreateOrOnNewIntent(intent: Intent?) {
     if (intent == null) return
     val extras = intent.extras ?: bundleOf()
     val payloadData = mutableMapOf<String, Any>()
+
+    val isNotificationClicked =
+        extras.containsKey(ACTION_NOTIFICATION_CLICK)
+                || extras.containsKey(KEY_ANDROID_FIREBASE_NOTIFICATION)
+                || payloadData.containsKey(ACTION_NOTIFICATION_CLICK)
+
     extras.keySet().forEach { key ->
         val value = extras.get(key)
-        value?.let { payloadData[key] = value }
+        value?.let { payloadData[key] = it }
     }
-    if (extras.containsKey("google.sent_time")) NotifierManagerImpl.onPushPayloadData(payloadData)
+
+
+    if (extras.containsKey(KEY_ANDROID_FIREBASE_NOTIFICATION))
+        NotifierManagerImpl.onPushPayloadData(payloadData.minus(ACTION_NOTIFICATION_CLICK))
+    if (isNotificationClicked)
+        NotifierManagerImpl.onNotificationClicked(payloadData.minus(ACTION_NOTIFICATION_CLICK))
 }
 
 internal fun NotifierManagerImpl.shouldShowNotification(): Boolean {

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
@@ -2,6 +2,7 @@ package com.mmk.kmpnotifier.firebase
 
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.mmk.kmpnotifier.Constants
 import com.mmk.kmpnotifier.extensions.shouldShowNotification
 import com.mmk.kmpnotifier.notification.Notifier
 import com.mmk.kmpnotifier.notification.NotifierManager
@@ -27,7 +28,8 @@ internal class MyFirebaseMessagingService : FirebaseMessagingService() {
             notifierManager.onPushNotification(title = it.title, body = it.body)
         }
         if (message.data.isNotEmpty()) {
-            notifierManager.onPushPayloadData(message.data)
+            val data = message.data + mapOf( Constants.ACTION_NOTIFICATION_CLICK to Constants.ACTION_NOTIFICATION_CLICK)
+            notifierManager.onPushPayloadData(data)
         }
     }
 }

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/AndroidNotifier.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/AndroidNotifier.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import com.mmk.kmpnotifier.Constants.ACTION_NOTIFICATION_CLICK
 import com.mmk.kmpnotifier.extensions.notificationManager
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
@@ -21,7 +22,7 @@ internal class AndroidNotifier(
 ) : Notifier {
 
     override fun notify(title: String, body: String): Int {
-        val notificationID = Random.nextInt(0,Int.MAX_VALUE)
+        val notificationID = Random.nextInt(0, Int.MAX_VALUE)
         notify(notificationID, title, body)
         return notificationID
     }
@@ -66,7 +67,9 @@ internal class AndroidNotifier(
     }
 
     private fun getPendingIntent(deepLink: String = ""): PendingIntent? {
-        val intent = getLauncherActivityIntent()
+        val intent = getLauncherActivityIntent()?.apply {
+            putExtra(ACTION_NOTIFICATION_CLICK, ACTION_NOTIFICATION_CLICK)
+        }
         intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
         val flags =

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/Constants.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/Constants.kt
@@ -1,0 +1,7 @@
+package com.mmk.kmpnotifier
+
+internal object Constants {
+    const val KEY_ANDROID_FIREBASE_NOTIFICATION = "google.sent_time"
+    const val KEY_IOS_FIREBASE_NOTIFICATION = "gcm.message_id"
+    const val ACTION_NOTIFICATION_CLICK = "com.mmk.kmpnotifier.notification.ACTION_NOTIFICATION_CLICK"
+}

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
@@ -58,6 +58,12 @@ public object NotifierManager {
          * @param body Notification body message
          */
         public fun onPushNotification(title:String?,body:String?) {}
+
+        /**
+         * Called when notification is clicked
+         * @param data Push Notification Payload Data
+         */
+        public fun onNotificationClicked(data: PayloadData) {}
     }
 
 

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
@@ -6,7 +6,6 @@ import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfig
 import org.koin.core.component.get
 
 internal object NotifierManagerImpl : KMPKoinComponent() {
-
     private val listeners = mutableListOf<NotifierManager.Listener>()
 
     fun initialize(configuration: NotificationPlatformConfiguration) {
@@ -43,6 +42,12 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
         println("Received Push Notification notification type message")
         if (listeners.size == 0) println("There is no listener to notify onPushNotification")
         listeners.forEach { it.onPushNotification(title = title, body = body) }
+    }
+
+    fun onNotificationClicked(data: PayloadData) {
+        println("Notification is clicked")
+        if (listeners.size == 0) println("There is no listener to notify onPushPayloadData")
+        listeners.forEach { it.onNotificationClicked(data) }
     }
 
     private fun requireInitialization() {

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.ios.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.extensions
 
+import com.mmk.kmpnotifier.Constants.KEY_IOS_FIREBASE_NOTIFICATION
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
@@ -25,7 +26,7 @@ public fun NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: M
         .filterIsInstance<String>()
         .associateWith { key -> userInfo[key] }
 
-    if (payloadData.containsKey("gcm.message_id")) NotifierManagerImpl.onPushPayloadData(payloadData)
+    if (payloadData.containsKey(KEY_IOS_FIREBASE_NOTIFICATION)) NotifierManagerImpl.onPushPayloadData(payloadData)
 }
 
 internal fun NotifierManager.onUserNotification(notificationContent: UNNotificationContent) {
@@ -48,5 +49,5 @@ internal fun NotifierManager.shouldShowNotification(notificationContent: UNNotif
 }
 
 private fun UNNotificationContent.isPushNotification(): Boolean {
-    return userInfo.containsKey("gcm.message_id")
+    return userInfo.containsKey(KEY_IOS_FIREBASE_NOTIFICATION)
 }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
@@ -64,6 +64,8 @@ internal class IosNotifier(
             withCompletionHandler: () -> Unit,
         ) {
             val notificationContent = didReceiveNotificationResponse.notification.request.content
+            val actionIdentifier = didReceiveNotificationResponse.actionIdentifier
+            println("ActionIdentifier: $actionIdentifier")
             NotifierManager.onUserNotification(notificationContent)
             if (NotifierManager.shouldShowNotification(notificationContent)) withCompletionHandler()
         }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
@@ -1,6 +1,7 @@
 package com.mmk.kmpnotifier.notification
 
 import com.mmk.kmpnotifier.extensions.onApplicationDidReceiveRemoteNotification
+import com.mmk.kmpnotifier.extensions.onNotificationClicked
 import com.mmk.kmpnotifier.extensions.onUserNotification
 import com.mmk.kmpnotifier.extensions.shouldShowNotification
 import com.mmk.kmpnotifier.permission.IosPermissionUtil
@@ -64,9 +65,8 @@ internal class IosNotifier(
             withCompletionHandler: () -> Unit,
         ) {
             val notificationContent = didReceiveNotificationResponse.notification.request.content
-            val actionIdentifier = didReceiveNotificationResponse.actionIdentifier
-            println("ActionIdentifier: $actionIdentifier")
             NotifierManager.onUserNotification(notificationContent)
+            NotifierManager.onNotificationClicked(notificationContent)
             if (NotifierManager.shouldShowNotification(notificationContent)) withCompletionHandler()
         }
 

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
@@ -21,6 +21,11 @@ object AppInitializer {
                 super.onPayloadData(data)
                 println("Push Notification payloadData: $data")
             }
+
+            override fun onNotificationClicked(data: PayloadData) {
+                super.onNotificationClicked(data)
+                println("Notification clicked, Notification payloadData: $data")
+            }
         })
     }
 }


### PR DESCRIPTION
Based on this issue https://github.com/mirzemehdi/KMPNotifier/issues/19

#### Detecting notification click and get payload data
```kotlin
NotifierManager.addListener(object : NotifierManager.Listener {
    override fun onNotificationClicked(data: PayloadData) {
        super.onNotificationClicked(data)
        println("Notification clicked, Notification payloadData: $data")
    }
}) 
``` 

You need to call below platform-specific functions in order to receive payload data properly.

##### Android
Call `NotifierManager.onCreateOrOnNewIntent(intent)` on launcher Activity's `onCreate` and `onNewIntent` methods.
```kotlin
override fun onCreate(savedInstanceState: Bundle?) {
   super.onCreate(savedInstanceState)
      NotifierManager.onCreateOrOnNewIntent(intent)
      ...
    }

    override fun onNewIntent(intent: Intent?) {
        super.onNewIntent(intent)
        NotifierManager.onCreateOrOnNewIntent(intent)
    }

```

##### iOS
Call `NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)` on application's `didReceiveRemoteNotification` method.

```
 func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) async -> UIBackgroundFetchResult {
      NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
      return UIBackgroundFetchResult.newData
 }

``` 