### PR TITLE
Fixing Xcode warning:  registerForRemoteNotifications must be used from main thread 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 allprojects {
     group = "io.github.mirzemehdi"
-    version = "1.0.0"
+    version = "1.0.1"
     val sonatypeUsername = gradleLocalProperties(rootDir).getProperty("sonatypeUsername")
     val sonatypePassword = gradleLocalProperties(rootDir).getProperty("sonatypePassword")
     val gpgKeySecret = gradleLocalProperties(rootDir).getProperty("gpgKeySecret")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,11 +19,13 @@ koin = "3.5.6"
 kotlinx-binary-validator = "0.13.2"
 dokka = "1.9.10"
 firebase-messaging = "24.0.0"
+kotlinx-coroutine = "1.9.0-RC"
 
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlinx-coroutine = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutine" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }

--- a/kmpnotifier/build.gradle.kts
+++ b/kmpnotifier/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(libs.koin.core)
+            implementation(libs.kotlinx.coroutine)
         }
     }
 }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
@@ -5,6 +5,8 @@ import cocoapods.FirebaseMessaging.FIRMessagingDelegateProtocol
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 import com.mmk.kmpnotifier.notification.PushNotifier
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import platform.UIKit.UIApplication
 import platform.UIKit.registerForRemoteNotifications
 import platform.darwin.NSObject
@@ -16,9 +18,12 @@ import kotlin.coroutines.suspendCoroutine
 internal class FirebasePushNotifierImpl : PushNotifier {
 
     init {
-        println("FirebasePushNotifier is initialized")
-        UIApplication.sharedApplication.registerForRemoteNotifications()
-        FIRMessaging.messaging().delegate = FirebaseMessageDelegate()
+        MainScope().launch {
+            println("FirebasePushNotifier is initialized")
+            UIApplication.sharedApplication.registerForRemoteNotifications()
+            FIRMessaging.messaging().delegate = FirebaseMessageDelegate()
+        }
+
     }
 
 


### PR DESCRIPTION
Fixing https://github.com/mirzemehdi/KMPNotifier/issues/37