### PR TITLE
Change onPermissionGranted to onPermissionResult(isGranted: Boolean)

### DIFF
--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/permission/AndroidMockPermissionUtil.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/permission/AndroidMockPermissionUtil.kt
@@ -13,7 +13,7 @@ internal class AndroidMockPermissionUtil(private val context: Context) : Permiss
         onPermissionResult(context.hasNotificationPermission())
     }
 
-    override fun askNotificationPermission(onPermissionGranted: () -> Unit) = Unit.also {
+    override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) = Unit.also {
         println(
             "In Android this function is just a mock. You need to ask permission in Activity " +
                     "using like below: \n" +

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/EmptyPermissionUtilImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/EmptyPermissionUtilImpl.kt
@@ -6,8 +6,8 @@ internal class EmptyPermissionUtilImpl : PermissionUtil {
         onPermissionResult(true)
     }
 
-    override fun askNotificationPermission(onPermissionGranted: () -> Unit) {
+    override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
         println("Not implemented: granted permission by default")
-        onPermissionGranted()
+        onPermissionResult(true)
     }
 }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/PermissionUtil.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/PermissionUtil.kt
@@ -6,6 +6,6 @@ package com.mmk.kmpnotifier.permission
 public interface PermissionUtil {
 
 
-    public fun hasNotificationPermission(onPermissionResult: (Boolean) -> Unit = {})
-    public fun askNotificationPermission(onPermissionGranted: () -> Unit = {})
+    public fun hasNotificationPermission(onPermissionResult: (isGranted: Boolean) -> Unit = {})
+    public fun askNotificationPermission(onPermissionResult: (isGranted: Boolean) -> Unit = {})
 }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/permission/IosPermissionUtil.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/permission/IosPermissionUtil.kt
@@ -7,7 +7,8 @@ import platform.UserNotifications.UNAuthorizationOptionSound
 import platform.UserNotifications.UNAuthorizationStatusAuthorized
 import platform.UserNotifications.UNUserNotificationCenter
 
-internal class IosPermissionUtil(private val notificationCenter: UNUserNotificationCenter) : PermissionUtil {
+internal class IosPermissionUtil(private val notificationCenter: UNUserNotificationCenter) :
+    PermissionUtil {
     companion object {
         val NOTIFICATION_PERMISSIONS =
             UNAuthorizationOptionAlert or
@@ -21,13 +22,13 @@ internal class IosPermissionUtil(private val notificationCenter: UNUserNotificat
         }
     }
 
-    override fun askNotificationPermission(onPermissionGranted: () -> Unit) {
+    override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
         notificationCenter.requestAuthorizationWithOptions(NOTIFICATION_PERMISSIONS) { isGranted, _ ->
             if (isGranted) {
                 UNUserNotificationCenter.currentNotificationCenter().delegate =
                     IosNotifier.NotificationDelegate()
-                onPermissionGranted()
             }
+            onPermissionResult(isGranted)
         }
     }
 }

--- a/kmpnotifier/src/jsMain/kotlin/com/mmk/kmpnotifier/permission/WebPermissionUtilImpl.kt
+++ b/kmpnotifier/src/jsMain/kotlin/com/mmk/kmpnotifier/permission/WebPermissionUtilImpl.kt
@@ -10,9 +10,9 @@ internal class WebPermissionUtilImpl : PermissionUtil {
         onPermissionResult(permission == NotificationPermission.GRANTED)
     }
 
-    override fun askNotificationPermission(onPermissionGranted: () -> Unit) {
+    override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
         Notification.requestPermission().then {
-            onPermissionGranted()
+            onPermissionResult(it == NotificationPermission.GRANTED)
             null
         }
     }

--- a/kmpnotifier/src/wasmJsMain/kotlin/com/mmk/kmpnotifier/permission/WebPermissionUtilImpl.kt
+++ b/kmpnotifier/src/wasmJsMain/kotlin/com/mmk/kmpnotifier/permission/WebPermissionUtilImpl.kt
@@ -10,9 +10,9 @@ internal class WebPermissionUtilImpl : PermissionUtil {
         onPermissionResult(permission == NotificationPermission.GRANTED)
     }
 
-    override fun askNotificationPermission(onPermissionGranted: () -> Unit) {
+    override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
         Notification.requestPermission().then {
-            onPermissionGranted()
+            onPermissionResult(it == NotificationPermission.GRANTED)
             null
         }
     }


### PR DESCRIPTION
First of all, great library and thanks for maintaining it actively!

Currently the `PermissionUtil.askNotificationPermission.onPermissionGranted` callback only triggers when the permission was actually granted. I would like to receive a negative response too so I can handle it accordingly. This PR adds this functionality.