### PR TITLE
Add an option to initialize by passing Android Context instance 

### DIFF
--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/extensions/NotifierManagerExt.kt
@@ -1,9 +1,11 @@
 package com.mmk.kmpnotifier.extensions
 
+import android.content.Context
 import android.content.Intent
 import androidx.core.os.bundleOf
 import com.mmk.kmpnotifier.Constants.ACTION_NOTIFICATION_CLICK
 import com.mmk.kmpnotifier.Constants.KEY_ANDROID_FIREBASE_NOTIFICATION
+import com.mmk.kmpnotifier.di.ContextInitializer
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
@@ -54,6 +56,23 @@ public fun NotifierManager.onCreateOrOnNewIntent(intent: Intent?) {
         NotifierManagerImpl.onPushPayloadData(payloadData.minus(ACTION_NOTIFICATION_CLICK))
     if (isNotificationClicked)
         NotifierManagerImpl.onNotificationClicked(payloadData.minus(ACTION_NOTIFICATION_CLICK))
+}
+
+
+/**
+ * @param context Android application context. By default
+ * using androidx-startup Context reference is passed without needing to pass one manually.
+ * If you disabled androidx-startup you can use this function in android application start to pass Context reference
+ * @param configuration pass android configuration
+ * @see NotificationPlatformConfiguration.Android
+ *
+ */
+public fun NotifierManager.initialize(
+    context: Context,
+    configuration: NotificationPlatformConfiguration
+) {
+    ContextInitializer().create(context)
+    NotifierManagerImpl.initialize(configuration)
 }
 
 internal fun NotifierManagerImpl.shouldShowNotification(): Boolean {

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
@@ -33,6 +33,7 @@ fun App() {
             }
         })
         myPushNotificationToken = NotifierManager.getPushNotifier().getToken() ?: ""
+        println("Firebase Token: $myPushNotificationToken")
     }
 
 


### PR DESCRIPTION

Solves: https://github.com/mirzemehdi/KMPNotifier/issues/63
Related comment: https://github.com/mirzemehdi/KMPNotifier/issues/53#issuecomment-2266379524


By default using `androidx-startup` Context instance is obtained automatically in android. But if you disabled androidx-startup, you can pass android Context instance using initialize method as below:

```kotlin

class MyApplication : Application() {
   override fun onCreate() {
       super.onCreate()
       NotifierManager.initialize(
           context = this
           configuration = NotificationPlatformConfiguration.Android(
               notificationIconResId = R.drawable.ic_launcher_foreground,
               showPushNotification = true,
           )
       )
   }
}

```

