### PR TITLE
Add Logger implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,13 @@ For setting custom notification sound, check https://github.com/mirzemehdi/KMPNo
 For setting Intent data in Android (for deeplink), check https://github.com/mirzemehdi/KMPNotifier/pull/60#issue-2454489089    
 For permissionUtil, or manually asking notification permission check https://github.com/mirzemehdi/KMPNotifier/pull/27#issuecomment-2083639907  
 
+### Logging
 
+If you want to see internal logs of the library, you can set a logger using:
 
-
-
+```kotlin
+NotifierManager.setLogger { message ->
+    // Log the message
+    println(message)
+}
+```

--- a/kmpnotifier/api/android/kmpnotifier.api
+++ b/kmpnotifier/api/android/kmpnotifier.api
@@ -3,6 +3,10 @@ public final class com/mmk/kmpnotifier/extensions/NotifierManagerExtKt {
 	public static final fun onCreateOrOnNewIntent (Lcom/mmk/kmpnotifier/notification/NotifierManager;Landroid/content/Intent;)V
 }
 
+public abstract interface class com/mmk/kmpnotifier/logger/Logger {
+	public abstract fun log (Ljava/lang/String;)V
+}
+
 public abstract class com/mmk/kmpnotifier/notification/NotificationImage {
 }
 
@@ -70,6 +74,7 @@ public final class com/mmk/kmpnotifier/notification/NotifierManager {
 	public final fun getPushNotifier ()Lcom/mmk/kmpnotifier/notification/PushNotifier;
 	public final fun initialize (Lcom/mmk/kmpnotifier/notification/configuration/NotificationPlatformConfiguration;)V
 	public final fun setListener (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;)V
+	public final fun setLogger (Lcom/mmk/kmpnotifier/logger/Logger;)V
 }
 
 public abstract interface class com/mmk/kmpnotifier/notification/NotifierManager$Listener {

--- a/kmpnotifier/api/jvm/kmpnotifier.api
+++ b/kmpnotifier/api/jvm/kmpnotifier.api
@@ -2,6 +2,10 @@ public final class com/mmk/kmpnotifier/extensions/DesktopPlatformExtKt {
 	public static final fun composeDesktopResourcesPath ()Ljava/lang/String;
 }
 
+public abstract interface class com/mmk/kmpnotifier/logger/Logger {
+	public abstract fun log (Ljava/lang/String;)V
+}
+
 public abstract class com/mmk/kmpnotifier/notification/NotificationImage {
 }
 
@@ -69,6 +73,7 @@ public final class com/mmk/kmpnotifier/notification/NotifierManager {
 	public final fun getPushNotifier ()Lcom/mmk/kmpnotifier/notification/PushNotifier;
 	public final fun initialize (Lcom/mmk/kmpnotifier/notification/configuration/NotificationPlatformConfiguration;)V
 	public final fun setListener (Lcom/mmk/kmpnotifier/notification/NotifierManager$Listener;)V
+	public final fun setLogger (Lcom/mmk/kmpnotifier/logger/Logger;)V
 }
 
 public abstract interface class com/mmk/kmpnotifier/notification/NotifierManager$Listener {

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
@@ -1,6 +1,7 @@
 package com.mmk.kmpnotifier.firebase
 
 import com.google.firebase.messaging.FirebaseMessaging
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.PushNotifier
 import kotlinx.coroutines.tasks.asDeferred
 import kotlin.coroutines.cancellation.CancellationException
@@ -8,7 +9,7 @@ import kotlin.coroutines.cancellation.CancellationException
 internal class FirebasePushNotifierImpl : PushNotifier {
 
     init {
-        println("FirebasePushNotifier is initialized")
+        currentLogger.log("FirebasePushNotifier is initialized")
     }
 
     override suspend fun getToken(): String? {
@@ -17,7 +18,7 @@ internal class FirebasePushNotifierImpl : PushNotifier {
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             null.also {
-                println("Error while getting token: $e")
+                currentLogger.log("Error while getting token: $e")
             }
         }
     }

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
@@ -4,10 +4,9 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.mmk.kmpnotifier.Constants
 import com.mmk.kmpnotifier.extensions.shouldShowNotification
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.Notifier
-import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
-import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 
 internal class MyFirebaseMessagingService : FirebaseMessagingService() {
 
@@ -15,7 +14,7 @@ internal class MyFirebaseMessagingService : FirebaseMessagingService() {
     private val notifier: Notifier by lazy { notifierManager.getLocalNotifier() }
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        println("FirebaseMessaging: onNewToken is called")
+        currentLogger.log("FirebaseMessaging: onNewToken is called")
         notifierManager.onNewToken(token)
     }
 

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/permission/AndroidMockPermissionUtil.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/permission/AndroidMockPermissionUtil.kt
@@ -2,6 +2,7 @@ package com.mmk.kmpnotifier.permission
 
 import android.content.Context
 import com.mmk.kmpnotifier.extensions.hasNotificationPermission
+import com.mmk.kmpnotifier.logger.currentLogger
 
 
 /**
@@ -14,7 +15,7 @@ internal class AndroidMockPermissionUtil(private val context: Context) : Permiss
     }
 
     override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) = Unit.also {
-        println(
+        currentLogger.log(
             "In Android this function is just a mock. You need to ask permission in Activity " +
                     "using like below: \n" +
                     "val permissionUtil by permissionUtil()\n" +

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/di/LibDependencyInitializer.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/di/LibDependencyInitializer.kt
@@ -1,6 +1,6 @@
 package com.mmk.kmpnotifier.di
 
-
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.PushNotifier
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
@@ -8,7 +8,6 @@ import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
-
 
 internal object LibDependencyInitializer {
     var koinApp: KoinApplication? = null
@@ -34,7 +33,7 @@ internal object LibDependencyInitializer {
 }
 
 private fun Koin.onLibraryInitialized() {
-    println("Library is initialized")
+    currentLogger.log("Library is initialized")
     val permissionUtil by inject<PermissionUtil>()
     val platform by inject<Platform>()
     val configuration by inject<NotificationPlatformConfiguration>()
@@ -59,4 +58,3 @@ private fun Koin.onLibraryInitialized() {
 
     }
 }
-

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/logger/Logger.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/logger/Logger.kt
@@ -1,0 +1,27 @@
+package com.mmk.kmpnotifier.logger
+
+/**
+ * Global logger interface for the KMPNotifier library.
+ */
+public fun interface Logger {
+    /**
+     * Log a message.
+     *
+     * @param message The message to log
+     */
+    public fun log(message: String)
+}
+
+/**
+ * Default empty logger implementation that doesn't log anything.
+ */
+internal object EmptyLogger : Logger {
+    override fun log(message: String) {
+        // Empty
+    }
+}
+
+/**
+ * The current logger used by the library.
+ */
+internal var currentLogger: Logger = EmptyLogger

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/EmptyPushNotifierImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/EmptyPushNotifierImpl.kt
@@ -1,21 +1,23 @@
 package com.mmk.kmpnotifier.notification
 
+import com.mmk.kmpnotifier.logger.currentLogger
+
 
 internal class EmptyPushNotifierImpl : PushNotifier {
     override suspend fun getToken(): String? {
-        println("Not implemented: Get firebase token returns null")
+        currentLogger.log("Not implemented: Get firebase token returns null")
         return null
     }
 
     override suspend fun deleteMyToken() {
-        println("Not implemented: Delete firebase token is called")
+        currentLogger.log("Not implemented: Delete firebase token is called")
     }
 
     override suspend fun subscribeToTopic(topic: String) {
-        println("Not implemented: Subscribe firebase topic is called")
+        currentLogger.log("Not implemented: Subscribe firebase topic is called")
     }
 
     override suspend fun unSubscribeFromTopic(topic: String) {
-        println("Not implemented: Unsubscribe firebase topic is called")
+        currentLogger.log("Not implemented: Unsubscribe firebase topic is called")
     }
 }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification
 
+import com.mmk.kmpnotifier.logger.Logger
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
 
@@ -89,5 +90,13 @@ public object NotifierManager {
         public fun onNotificationClicked(data: PayloadData) {}
     }
 
-
+    /**
+     * Sets a custom logger for the library to use.
+     * By default, the library uses an empty logger that doesn't log anything.
+     *
+     * @param logger The logger to use
+     */
+    public fun setLogger(logger: Logger) {
+        NotifierManagerImpl.setLogger(logger)
+    }
 }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
@@ -2,6 +2,8 @@ package com.mmk.kmpnotifier.notification
 
 import com.mmk.kmpnotifier.di.KMPKoinComponent
 import com.mmk.kmpnotifier.di.LibDependencyInitializer
+import com.mmk.kmpnotifier.logger.Logger
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
 import org.koin.core.component.get
@@ -44,20 +46,20 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
     }
 
     fun onPushPayloadData(data: PayloadData) {
-        println("Received Push Notification payload data")
-        if (listeners.size == 0) println("There is no listener to notify onPushPayloadData")
+        currentLogger.log("Received Push Notification payload data")
+        if (listeners.size == 0) currentLogger.log("There is no listener to notify onPushPayloadData")
         listeners.forEach { it.onPayloadData(data) }
     }
 
     fun onPushNotification(title: String?, body: String?) {
-        println("Received Push Notification notification type message")
-        if (listeners.size == 0) println("There is no listener to notify onPushNotification")
+        currentLogger.log("Received Push Notification notification type message")
+        if (listeners.size == 0) currentLogger.log("There is no listener to notify onPushNotification")
         listeners.forEach { it.onPushNotification(title = title, body = body) }
     }
 
     fun onNotificationClicked(data: PayloadData) {
-        println("Notification is clicked")
-        if (listeners.size == 0) println("There is no listener to notify onPushPayloadData")
+        currentLogger.log("Notification is clicked")
+        if (listeners.size == 0) currentLogger.log("There is no listener to notify onPushPayloadData")
         listeners.forEach { it.onNotificationClicked(data) }
     }
 
@@ -68,4 +70,7 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
         )
     }
 
+    fun setLogger(logger: Logger) {
+        currentLogger = logger
+    }
 }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/EmptyPermissionUtilImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/permission/EmptyPermissionUtilImpl.kt
@@ -1,13 +1,15 @@
 package com.mmk.kmpnotifier.permission
 
+import com.mmk.kmpnotifier.logger.currentLogger
+
 internal class EmptyPermissionUtilImpl : PermissionUtil {
     override fun hasNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
-        println("Not implemented: has permission result: true")
+        currentLogger.log("Not implemented: has permission result: true")
         onPermissionResult(true)
     }
 
     override fun askNotificationPermission(onPermissionResult: (Boolean) -> Unit) {
-        println("Not implemented: granted permission by default")
+        currentLogger.log("Not implemented: granted permission by default")
         onPermissionResult(true)
     }
 }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/firebase/FirebasePushNotifierImpl.kt
@@ -2,6 +2,7 @@ package com.mmk.kmpnotifier.firebase
 
 import cocoapods.FirebaseMessaging.FIRMessaging
 import cocoapods.FirebaseMessaging.FIRMessagingDelegateProtocol
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 import com.mmk.kmpnotifier.notification.PushNotifier
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -21,7 +22,7 @@ internal class FirebasePushNotifierImpl : PushNotifier {
 
     init {
         MainScope().launch {
-            println("FirebasePushNotifier is initialized")
+            currentLogger.log("FirebasePushNotifier is initialized")
             FIRMessaging.messaging().delegate = firebaseMessageDelegate
             UIApplication.sharedApplication.registerForRemoteNotifications()
         }
@@ -32,7 +33,7 @@ internal class FirebasePushNotifierImpl : PushNotifier {
     override suspend fun getToken(): String? = suspendCoroutine { cont ->
         FIRMessaging.messaging().tokenWithCompletion { token, error ->
             cont.resume(token)
-            error?.let { println("Error while getting token: $error") }
+            error?.let { currentLogger.log("Error while getting token: $error") }
         }
 
     }
@@ -56,7 +57,7 @@ internal class FirebasePushNotifierImpl : PushNotifier {
         private val notifierManager by lazy { NotifierManagerImpl }
         override fun messaging(messaging: FIRMessaging, didReceiveRegistrationToken: String?) {
             didReceiveRegistrationToken?.let { token ->
-                println("FirebaseMessaging: onNewToken is called")
+                currentLogger.log("FirebaseMessaging: onNewToken is called")
                 notifierManager.onNewToken(didReceiveRegistrationToken)
             }
         }

--- a/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
+++ b/kmpnotifier/src/iosMain/kotlin/com/mmk/kmpnotifier/notification/IosNotifier.kt
@@ -3,6 +3,7 @@ package com.mmk.kmpnotifier.notification
 import com.mmk.kmpnotifier.extensions.onNotificationClicked
 import com.mmk.kmpnotifier.extensions.onUserNotification
 import com.mmk.kmpnotifier.extensions.shouldShowNotification
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.IosPermissionUtil
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -83,7 +84,7 @@ internal class IosNotifier(
                     trigger = trigger
                 )
                 notificationCenter.addNotificationRequest(notificationRequest) { error ->
-                    error?.let { println("Error showing notification: $error") }
+                    error?.let { currentLogger.log("Error showing notification: $error") }
                 }
             }
         }
@@ -141,7 +142,7 @@ internal class IosNotifier(
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                println("Error creating notification attachment: $e")
+                currentLogger.log("Error creating notification attachment: $e")
                 null
             }
         }
@@ -173,6 +174,3 @@ internal class IosNotifier(
         }
     }
 }
-
-
-

--- a/kmpnotifier/src/jsMain/kotlin/com/mmk/kmpnotifier/notification/WebConsoleNotifier.kt
+++ b/kmpnotifier/src/jsMain/kotlin/com/mmk/kmpnotifier/notification/WebConsoleNotifier.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification
 
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
 import kotlinx.browser.window
@@ -49,12 +50,12 @@ internal class WebConsoleNotifier(
     }
 
     override fun remove(id: Int) {
-        println("remove notification is not implemented ")
+        currentLogger.log("remove notification is not implemented ")
 
     }
 
     override fun removeAll() {
-        println("remove notification is not implemented ")
+        currentLogger.log("remove notification is not implemented ")
     }
 
     private fun showNotification(title: String, body: String) {

--- a/kmpnotifier/src/jvmMain/kotlin/com/mmk/kmpnotifier/notification/impl/JOptionPaneNotifier.kt
+++ b/kmpnotifier/src/jvmMain/kotlin/com/mmk/kmpnotifier/notification/impl/JOptionPaneNotifier.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification.impl
 
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.Notifier
 import com.mmk.kmpnotifier.notification.NotifierBuilder
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
@@ -41,10 +42,10 @@ internal class JOptionPaneNotifier(private val configuration: NotificationPlatfo
     }
 
     override fun remove(id: Int) {
-        println("No remove functionality")
+        currentLogger.log("No remove functionality")
     }
 
     override fun removeAll() {
-        println("No removeAll functionality")
+        currentLogger.log("No removeAll functionality")
     }
 }

--- a/kmpnotifier/src/jvmMain/kotlin/com/mmk/kmpnotifier/notification/impl/TrayNotifier.kt
+++ b/kmpnotifier/src/jvmMain/kotlin/com/mmk/kmpnotifier/notification/impl/TrayNotifier.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification.impl
 
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.Notifier
 import com.mmk.kmpnotifier.notification.NotifierBuilder
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
@@ -16,9 +17,9 @@ internal class TrayNotifier(private val configuration: NotificationPlatformConfi
     companion object {
         val isSupported by lazy {
             SystemTray.isSupported().also {
-                if (it.not()) System.err.println(
-                    "Tray is not supported on the current platform. "
-                )
+                if (it.not()) {
+                    currentLogger.log("Tray is not supported on the current platform.")
+                }
             }
         }
     }

--- a/kmpnotifier/src/wasmJsMain/kotlin/com/mmk/kmpnotifier/notification/WebConsoleNotifier.kt
+++ b/kmpnotifier/src/wasmJsMain/kotlin/com/mmk/kmpnotifier/notification/WebConsoleNotifier.kt
@@ -1,5 +1,6 @@
 package com.mmk.kmpnotifier.notification
 
+import com.mmk.kmpnotifier.logger.currentLogger
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.permission.PermissionUtil
 import kotlinx.browser.window
@@ -52,12 +53,12 @@ internal class WebConsoleNotifier(
     }
 
     override fun remove(id: Int) {
-        println("remove notification is not implemented ")
+        currentLogger.log("remove notification is not implemented")
 
     }
 
     override fun removeAll() {
-        println("remove notification is not implemented ")
+        currentLogger.log("remove notification is not implemented")
     }
 
     private fun showNotification(title: String, body: String) {

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import com.mmk.kmpnotifier.notification.NotificationImage
 import com.mmk.kmpnotifier.notification.Notifier
 import com.mmk.kmpnotifier.notification.NotifierManager
-import io.github.mirzemehdi.sample.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import kotlin.random.Random
 
@@ -29,8 +28,10 @@ import kotlin.random.Random
 fun App() {
     var myPushNotificationToken by remember { mutableStateOf("") }
     LaunchedEffect(true) {
-
         println("LaunchedEffectApp is called")
+        NotifierManager.setLogger { message ->
+            println(message)
+        }
         NotifierManager.addListener(object : NotifierManager.Listener {
             override fun onNewToken(token: String) {
                 myPushNotificationToken = token
@@ -61,7 +62,8 @@ fun App() {
                         Notifier.KEY_URL to "https://github.com/mirzemehdi/KMPNotifier/",
                         "extraKey" to "randomValue"
                     )
-                    image = NotificationImage.Url("https://github.com/user-attachments/assets/a0f38159-b31d-4a47-97a7-cc230e15d30b")
+                    image =
+                        NotificationImage.Url("https://github.com/user-attachments/assets/a0f38159-b31d-4a47-97a7-cc230e15d30b")
                 }
             }) {
                 Text("Send Local Notification")

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/App.kt
@@ -29,9 +29,6 @@ fun App() {
     var myPushNotificationToken by remember { mutableStateOf("") }
     LaunchedEffect(true) {
         println("LaunchedEffectApp is called")
-        NotifierManager.setLogger { message ->
-            println(message)
-        }
         NotifierManager.addListener(object : NotifierManager.Listener {
             override fun onNewToken(token: String) {
                 myPushNotificationToken = token

--- a/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
+++ b/sample/src/commonMain/kotlin/com/mmk/kmpnotifier/sample/AppInitializer.kt
@@ -8,6 +8,9 @@ import com.mmk.kmpnotifier.notification.PushNotifier
 object AppInitializer {
     fun onApplicationStart() {
         onApplicationStartPlatformSpecific()
+        NotifierManager.setLogger { message ->
+            println(message)
+        }
         NotifierManager.addListener(object : NotifierManager.Listener {
             override fun onNewToken(token: String) {
                 println("Push Notification onNewToken: $token")


### PR DESCRIPTION
The library currently prints things on the standard output with no user control over it.

This PR adds a `Logger` interface, and replaces all `println` calls in the library implementation with usages of the new `Logger`. The default logger implementation is an empty logger that doesn't print the messages anywhere.

Fixes #108 

Edits and suggestions welcome!