### PR TITLE
feat(android): Add support for multiple notification channels

### DIFF
--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/di/PlatformModule.android.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/di/PlatformModule.android.kt
@@ -40,7 +40,7 @@ internal actual val platformModule = module {
             androidNotificationConfiguration = configuration,
             notificationChannelFactory = NotificationChannelFactory(
                 context = get(),
-                channelData = configuration.notificationChannelData
+                channelDataList = configuration.notificationChannelDataList
             ),
             permissionUtil = get()
         )

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
@@ -24,12 +24,14 @@ internal class MyFirebaseMessagingService : FirebaseMessagingService() {
         val payloadData = message.data
         val notification = message.notification
         notification?.let {
-            if (notifierManager.shouldShowNotification())
+            if (notifierManager.shouldShowNotification()){
+                payloadData["channelId"] = notification.channelId
                 notifier.notify(
                     title = notification.title ?: "",
                     body = notification.body ?: "",
                     payloadData = payloadData
                 )
+            }
 
             notifierManager.onPushNotification(title = notification.title, body = notification.body)
         }

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/AndroidNotifier.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/AndroidNotifier.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.net.Uri
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -20,6 +19,7 @@ import kotlinx.coroutines.withContext
 import java.net.URL
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.random.Random
+import androidx.core.net.toUri
 
 
 internal class AndroidNotifier(
@@ -63,13 +63,14 @@ internal class AndroidNotifier(
         val notificationManager = context.notificationManager ?: return
         val pendingIntent = getPendingIntent(builder.payloadData, builder.id)
         notificationChannelFactory.createChannels()
+        val channelId = builder.payloadData["channelId"] ?: androidNotificationConfiguration.notificationChannelDataList.first().id
         scope.launch {
             val imageBitmap = builder.image?.asBitmap()
             val notification = NotificationCompat.Builder(
                 context,
-                androidNotificationConfiguration.notificationChannelData.id
+                channelId
             ).apply {
-                setChannelId(androidNotificationConfiguration.notificationChannelData.id)
+                setChannelId(channelId)
                 setContentTitle(builder.title)
                 setContentText(builder.body)
                 imageBitmap?.let {
@@ -89,8 +90,6 @@ internal class AndroidNotifier(
             }.build()
             notificationManager.notify(builder.id, notification)
         }
-
-
     }
 
     override fun remove(id: Int) {
@@ -108,7 +107,7 @@ internal class AndroidNotifier(
             putExtra(ACTION_NOTIFICATION_CLICK, ACTION_NOTIFICATION_CLICK)
             payloadData.forEach { putExtra(it.key, it.value) }
             val urlData = payloadData.getOrDefault(Notifier.KEY_URL, null)
-            urlData?.let { setData(Uri.parse(urlData)) }
+            urlData?.let { setData(urlData.toUri()) }
         }
         intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
 

--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/NotificationChannelFactory.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/notification/NotificationChannelFactory.kt
@@ -4,33 +4,33 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.media.AudioAttributes
-import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
 import com.mmk.kmpnotifier.extensions.notificationManager
+import androidx.core.net.toUri
 
 internal class NotificationChannelFactory(
     private val context: Context,
-    private val channelData: NotificationPlatformConfiguration.Android.NotificationChannelData,
+    private val channelDataList: List<NotificationPlatformConfiguration.Android.NotificationChannelData>,
 ) {
 
     fun createChannels() {
         val notificationManager = context.notificationManager ?: return
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 
-        val channel = NotificationChannel(
-            channelData.id,
-            channelData.name,
-            NotificationManager.IMPORTANCE_HIGH
-        ).apply {
-            this.description = channelData.description
-            enableLights(true)
-            setSound(channelData.soundUri)
+        channelDataList.forEach { channelData ->
+            val channel = NotificationChannel(
+                channelData.id,
+                channelData.name,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                this.description = channelData.description
+                enableLights(true)
+                setSound(channelData.soundUri)
+            }
+            notificationManager.createNotificationChannel(channel)
         }
-
-        notificationManager.createNotificationChannel(channel)
-
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -40,7 +40,7 @@ internal class NotificationChannelFactory(
             .setUsage(AudioAttributes.USAGE_NOTIFICATION)
             .build()
 
-        val uri = soundUri?.let { Uri.parse(soundUri) }
+        val uri = soundUri?.let { soundUri.toUri() }
         if (uri != null && audioAttributes != null) {
             setSound(uri, audioAttributes)
         }

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/configuration/NotificationPlatformConfiguration.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/configuration/NotificationPlatformConfiguration.kt
@@ -11,7 +11,7 @@ public sealed interface NotificationPlatformConfiguration {
      *
      * @param  notificationIconResId icon ResourceId (R.drawable.ic_notification)
      * @param notificationIconColorResId optional icon color ResourceId (R.color.yellow)
-     * @param notificationChannelData optional notification channel data for General or Miscellaneous notifications
+     * @param notificationChannelDataList optional notification channels data for General or Miscellaneous notifications
      * @see NotificationChannelData
      * @param showPushNotification Default value is true, by default when push notification is
      * received it will be shown to user. When set to false, it will not be shown to user,
@@ -21,7 +21,7 @@ public sealed interface NotificationPlatformConfiguration {
     public class Android(
         public val notificationIconResId: Int,
         public val notificationIconColorResId: Int? = null,
-        public val notificationChannelData: NotificationChannelData = NotificationChannelData(),
+        public val notificationChannelDataList: List<NotificationChannelData> = listOf(NotificationChannelData()),
         public val showPushNotification: Boolean = true,
     ) : NotificationPlatformConfiguration {
 

--- a/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/Platform.android.kt
+++ b/sample/src/androidMain/kotlin/com/mmk/kmpnotifier/sample/Platform.android.kt
@@ -1,19 +1,20 @@
 package com.mmk.kmpnotifier.sample
 
 import android.content.ContentResolver
-import android.net.Uri
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
+import androidx.core.net.toUri
 
 actual fun onApplicationStartPlatformSpecific() {
     val customNotificationSound =
-        Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + "com.mmk.kmpnotifier.sample" + "/" + R.raw.custom_notification_sound)
+        (ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + "com.mmk.kmpnotifier.sample" + "/" + R.raw.custom_notification_sound).toUri()
     NotifierManager.initialize(
         configuration = NotificationPlatformConfiguration.Android(
             notificationIconResId = R.drawable.ic_launcher_foreground,
             showPushNotification = true,
-            notificationChannelData = NotificationPlatformConfiguration.Android.NotificationChannelData(
-                soundUri = customNotificationSound.toString()
+            notificationChannelDataList = listOf(NotificationPlatformConfiguration.Android.NotificationChannelData(
+                    soundUri = customNotificationSound.toString()
+                )
             )
         )
     )


### PR DESCRIPTION
This commit introduces the ability to configure and use multiple notification channels on Android.

- Replaced `notificationChannelData` with `notificationChannelDataList` in `NotificationPlatformConfiguration.Android`.
- The `NotificationChannelFactory` is updated to create all channels provided in the list.
- Notifications can now specify a `channelId` in their payload data to select which channel to be sent to. If not specified, the first channel in the configuration list is used as the default.
- Updated the Android sample app to reflect the new multiple channel configuration API.
- Replaced `Uri.parse()` with the `androidx.core.net.toUri()` extension function for consistency.